### PR TITLE
Convert num_planets to an int to prevent -n from crashing the program

### DIFF
--- a/play.py
+++ b/play.py
@@ -21,7 +21,7 @@ def call_engine(options):
     player2 = util.load_player(options.player2)
 
     # Generate or load the map
-    state, id = State.generate(options.num_planets)
+    state, id = State.generate(int(options.num_planets))
     if not options.quiet:
         print('-- Using map with id {} '.format(id))
         print('   Start state: ' + str(state))

--- a/tournament.py
+++ b/tournament.py
@@ -34,7 +34,7 @@ def run_tournament(options):
             else:
                 p = [b, a]
 
-            start, _ = State.generate(options.num_planets)
+            start, _ = State.generate(int(options.num_planets))
 
             winner = engine.play(bots[p[0]], bots[p[1]], start, verbose=False, outfile=None)
 


### PR DESCRIPTION
I received the error below when trying to use the -n flag.

Traceback (most recent call last):
  File "play.py", line 72, in <module>
    call_engine(options)
  File "play.py", line 24, in call_engine
    state, id = State.generate(options.num_planets)
  File "/home/infergo/planet-wars/api/_state.py", line 469, in generate
    for i in range(num_planets - 2):
TypeError: unsupported operand type(s) for -: 'str' and 'int'

(Bart van Dijk, 2598117)