### PR TITLE
AlphaBeta/Minimax/ML only playable as player 1

### DIFF
--- a/bots/alphabeta/alphabeta.py
+++ b/bots/alphabeta/alphabeta.py
@@ -11,12 +11,16 @@ class Bot:
 
     __max_depth = -1
     __randomize = True
+    __my_id = 0
 
     def __init__(self, randomize=True, depth=4):
         self.__randomize = randomize
         self.__max_depth = depth
 
     def get_move(self, state):
+        # Find out which player we are
+        self.__my_id = state.whose_turn()
+
         val, move = self.value(state)
 
         return move # to do nothing, return None
@@ -36,7 +40,7 @@ class Bot:
         if depth == self.__max_depth:
             return heuristic(state)
 
-        best_value = float('-inf') if maximizing(state) else float('inf')
+        best_value = float('-inf') if maximizing(state, self.__my_id) else float('inf')
         best_move = None
 
         moves = state.moves()
@@ -49,7 +53,7 @@ class Bot:
             next_state = state.next(move)
             value, _ = ???
 
-            if maximizing(state):
+            if maximizing(state, self.__my_id):
                 if value > best_value:
                     best_value = value
                     best_move = move
@@ -67,14 +71,14 @@ class Bot:
 
         return best_value, best_move
 
-def maximizing(state):
+def maximizing(state, my_id):
     """
     Whether we're the maximizing player (1) or the minimizing player (2).
 
     :param state:
     :return:
     """
-    return state.whose_turn() == 1
+    return state.whose_turn() == my_id
 
 def heuristic(state):
     return util.ratio_ships(state, 1) * 2.0 - 1.0, None

--- a/bots/minimax/minimax.py
+++ b/bots/minimax/minimax.py
@@ -11,6 +11,7 @@ class Bot:
 
     __max_depth = -1
     __randomize = True
+    __my_id = 0
 
     def __init__(self, randomize=True, depth=4):
         """
@@ -22,6 +23,9 @@ class Bot:
 
     def get_move(self, state):
         # type: (State) -> tuple[int, int]
+
+        # Find out which player we are
+        self.__my_id = state.whose_turn()
 
         val, move = self.value(state)
 
@@ -46,7 +50,7 @@ class Bot:
         if self.__randomize:
             random.shuffle(moves)
 
-        best_value = float('-inf') if maximizing(state) else float('inf')
+        best_value = float('-inf') if maximizing(state, self.__my_id) else float('inf')
         best_move = None
 
         for move in moves:
@@ -57,7 +61,7 @@ class Bot:
             # minimax value of 'next_state'
             value ???
 
-            if maximizing(state):
+            if maximizing(state, self.__my_id):
                 if value > best_value:
                     best_value = value
                     best_move = move
@@ -68,13 +72,13 @@ class Bot:
 
         return best_value, best_move
 
-def maximizing(state):
+def maximizing(state, my_id):
     # type: (State) -> bool
     """
     :param state:
     :return: True if we're the maximizing player (player 1), false otherwise (player 2).
     """
-    return state.whose_turn() == 1
+    return state.whose_turn() == my_id
 
 def heuristic(state):
     # type: (State) -> float

--- a/bots/ml/ml.py
+++ b/bots/ml/ml.py
@@ -17,6 +17,7 @@ class Bot:
     __randomize = True
 
     __model = None
+    __my_id = 0
 
     def __init__(self, randomize=True, depth=4, model_file=DEFAULT_MODEL):
 
@@ -28,6 +29,8 @@ class Bot:
         self.__model = joblib.load(model_file)
 
     def get_move(self, state):
+        # Find out which player we are
+        self.__my_id = state.whose_turn()
 
         val, move = self.value(state)
 
@@ -48,7 +51,7 @@ class Bot:
         if depth == self.__max_depth:
             return self.heuristic(state), None
 
-        best_value = float('-inf') if maximizing(state) else float('inf')
+        best_value = float('-inf') if maximizing(state, self.__my_id) else float('inf')
         best_move = None
 
         moves = state.moves()
@@ -60,7 +63,7 @@ class Bot:
 
             value ???
 
-            if maximizing(state):
+            if maximizing(state, self.__my_id):
                 if value > best_value:
                     best_value = value
                     best_move = move
@@ -96,13 +99,13 @@ class Bot:
 
         return res
 
-def maximizing(state):
+def maximizing(state, my_id):
     """
     Whether we're the maximizing player (1) or the minimizing player (2).
     :param state:
     :return:
     """
-    return state.whose_turn() == 1
+    return state.whose_turn() == my_id
 
 
 def features(state):


### PR DESCRIPTION
At the moment, the id of player 1 is hard coded into the AlphaBeta bot, Minimax bot and the ML bot. This results in the bots giving None moves when they're played as player 2. Because the algorithm isn't functioning properly.

This also caused a bug with `train-ml-bot.py` as you would get an `only 'lost' class contained in data` error. Many students encountered this error and posted about it in the blackboard discussion board.

This fix checks for the current players id and stores that in the class, and then compares that in the maximizing function. (Instead of comparing to `1`.)